### PR TITLE
Add consumer shutdown flag

### DIFF
--- a/Consumer.java
+++ b/Consumer.java
@@ -1,3 +1,6 @@
 public interface Consumer {
-    
-} 
+    /**
+     * Stop all running consumer threads gracefully.
+     */
+    void stopConsumers();
+}

--- a/ConsumerImpl.java
+++ b/ConsumerImpl.java
@@ -1,18 +1,23 @@
+import java.util.ArrayList;
+import java.util.List;
+
 public class ConsumerImpl implements Consumer{
-    
+
     private final CustomeQueue queue;
+    private final List<Thread> workers = new ArrayList<>();
+    private volatile boolean running = true;
 
     public ConsumerImpl(CustomeQueue queue) {
         this.queue = queue;
         for (int i = 0; i < 3; i++) {
             Thread worker = new Thread(() -> {
-                while (true) {
+                while (running) {
                     Task task = null;
                     System.out.println("current Thread" +Thread.currentThread().getName());
                     synchronized (queue) {
                         if (!queue.isEmpty()) {
                             task = queue.pullTask();
-                        }else{
+                        } else {
                             try {
                                 queue.wait();
                             } catch (InterruptedException e) {
@@ -20,6 +25,9 @@ public class ConsumerImpl implements Consumer{
                                 break;
                             }
                         }
+                    }
+                    if (!running) {
+                        break;
                     }
                     if (task != null) {
                         System.out.println(Thread.currentThread().getName()+" executing the task: "+task.getName());
@@ -35,6 +43,15 @@ public class ConsumerImpl implements Consumer{
                 }
             },("Thread"+i));
             worker.start();
+            workers.add(worker);
+        }
+    }
+
+    @Override
+    public void stopConsumers() {
+        running = false;
+        for (Thread worker : workers) {
+            worker.interrupt();
         }
     }
 }

--- a/Main.java
+++ b/Main.java
@@ -22,5 +22,14 @@ class Main{
                 }
             }
         }
-    }   
+        // allow consumers some time to finish remaining tasks
+        try {
+            Thread.sleep(3000);
+        } catch (InterruptedException e) {
+            Thread.currentThread().interrupt();
+        }
+
+        // gracefully stop consumer threads
+        consumer.stopConsumers();
+    }
 }


### PR DESCRIPTION
## Summary
- allow callers to stop consumers
- manage worker thread lifecycle with a running flag
- stop consumers from `Main` after producing tasks

## Testing
- `javac *.java`
- `java Main | head -n 5`

------
https://chatgpt.com/codex/tasks/task_e_6875aa108e1083279df72e0064b0d149